### PR TITLE
fix wrong separator

### DIFF
--- a/src/ContainerInstaller.php
+++ b/src/ContainerInstaller.php
@@ -22,8 +22,7 @@ class ContainerInstaller extends LibraryInstaller
 		if (isset($extras->apiato->container->name)) {
 			$containerName = $extras->apiato->container->name;
 		}
-		$separator = '\\';
-		return "app" . $separator . "Modules" . $separator . $containerName;
+		return "app" . DIRECTORY_SEPARATOR . "Modules" . DIRECTORY_SEPARATOR . $containerName;
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes the error of incorrect directory creation on Linux / MacOS systems. This happens because the wrong path is specified, which does not take into account the different directory separator in different operating systems.

screenshot: https://ibb.co/G3jrVfr